### PR TITLE
users can now view a list of comments for posts and delete their own

### DIFF
--- a/src/components/posts/postComments.js
+++ b/src/components/posts/postComments.js
@@ -8,12 +8,15 @@ export const Comments = () => {
     const { postId } = useParams()
     const [comments, setComments] = useState([])
     const navigate = useNavigate()
-    const localUser = localStorage.getItem("auth_token")
-    const userObject = JSON.parse(localUser)
+    
 
     useEffect(
         () => {
-            fetch(`http://localhost:8000/comments/${postId}`)
+            fetch(`http://localhost:8000/comments?post=${postId}`, {
+                headers: {
+                    "Authorization": `Token ${localStorage.getItem("auth_token")}`
+                }
+            })
                 .then(response => response.json())
                 .then((commentsArray) => {
                     setComments(commentsArray)
@@ -23,7 +26,12 @@ export const Comments = () => {
 
     const removeComment = (id) => {
         return fetch(`http://localhost:8000/comments/${id}`, {
-            method: "DELETE"
+            method: "DELETE",
+            headers: {
+                'Accept': 'application/json',
+                "Content-Type": "application/json",
+                "Authorization": `Token ${localStorage.getItem("auth_token")}`
+            }
         })
             .then(() => {
                 window.location.reload()
@@ -35,20 +43,22 @@ export const Comments = () => {
         <div className="commentsSection">
             {
                 comments.map((comment) => {
-                    let author = false
-                    if (comment.author_id === userObject) {
-                        author = true
-                    }
-                    return <li className="commentBox">
+                    
+                    return <div className="commentBox">
                         <div className="postInfo">
-                            <p>{comment?.content}</p>
+                            <p>{comment.content}</p>
                             {
-                                author
-                                    ? <button onClick={() => removeComment(comment.id)}>&#128465;</button>
-                                    : ""
+                                comment.created
+                                ? <button onClick = {
+                                    () => {
+                                        removeComment(comment.id)
+                                    }
+                                }>Delete</button>
+                                : ""
                             }
+                            
                         </div>
-                    </li>
+                    </div>
                 }
                 )
             }


### PR DESCRIPTION
# Description

users can now view all comments for each post and delete comments that are their own


Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


- [ ] Test A
- [ ] Test B

**To test this branch:
git fetch--all
cd ns-comments

in browser, make sure that you can view a list of comments for posts and if the logged in user is the author of the comment, a button to delete the comment should appear. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes